### PR TITLE
added __version__ attribute to the protocol module

### DIFF
--- a/Python/bluffinmuffin/protocol/__init__.py
+++ b/Python/bluffinmuffin/protocol/__init__.py
@@ -1,4 +1,4 @@
-from .info import __version__
+from .version import __version__
 
 from .command_decoder import CommandDecoder
 from .disconnect_command import DisconnectCommand

--- a/Python/bluffinmuffin/protocol/__init__.py
+++ b/Python/bluffinmuffin/protocol/__init__.py
@@ -1,3 +1,5 @@
+from .info import __version__
+
 from .command_decoder import CommandDecoder
 from .disconnect_command import DisconnectCommand
 

--- a/Python/bluffinmuffin/protocol/version.py
+++ b/Python/bluffinmuffin/protocol/version.py
@@ -1,0 +1,14 @@
+# BluffinMuffin.Protocol version information.  An empty _version_extra corresponds to a
+# full release.  '.dev' as a _version_extra string means this is a development
+# version
+_version_major = 2
+_version_minor = 2
+_version_micro = 0
+#_version_extra = 'dev'
+_version_extra = ''
+
+# Format expected by setup.py: string of form "X.Y.Z"
+__version__ = "%s.%s.%s%s" % (_version_major,
+                              _version_minor,
+                              _version_micro,
+                              _version_extra)

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,8 +1,13 @@
+import os
 from setuptools import setup, find_packages
+
+# Get __version__ which is stored in bluffinmuffin/protocol/version.py
+ver_file = os.path.join('bluffinmuffin', 'protocol', 'version.py')
+exec(open(ver_file).read())
 
 setup(
     name='bluffinmuffin.protocol',
-    version='2.2.0',
+    version=__version__,
     packages=find_packages(),
     namespace_packages=['bluffinmuffin'],
     url='',


### PR DESCRIPTION
We can now do:

``` python
import bluffinmuffin.protocol as proto
proto.__version__
```
